### PR TITLE
feat(trending): allow cors requests

### DIFF
--- a/pkg/trending/trending.go
+++ b/pkg/trending/trending.go
@@ -13,6 +13,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	response := youtube.GetTrendings()
 	serialied := youtube.SerializeTrending(response)
 	utils.JSONResponse(w)
+	utils.AllowCorsResponse(w, r)
 	utils.OkResponse(w)
 	utils.WriteBodyResponse(w, serialied)
 }

--- a/pkg/utils/response.go
+++ b/pkg/utils/response.go
@@ -20,6 +20,7 @@ func WriteBodyResponse(w http.ResponseWriter, body string) {
 	io.WriteString(w, body)
 }
 
+// AllowCorsResponse set proper CORS headers
 func AllowCorsResponse(w http.ResponseWriter, r *http.Request) {
 	switch origin := r.Header.Get("Origin"); origin {
 	case "http://localhost:8080", "https://yt.psmarcin.dev", "https://yt.psmarcin.me":

--- a/pkg/utils/response.go
+++ b/pkg/utils/response.go
@@ -19,3 +19,10 @@ func OkResponse(w http.ResponseWriter) {
 func WriteBodyResponse(w http.ResponseWriter, body string) {
 	io.WriteString(w, body)
 }
+
+func AllowCorsResponse(w http.ResponseWriter, r *http.Request) {
+	switch origin := r.Header.Get("Origin"); origin {
+	case "http://localhost:8080", "https://yt.psmarcin.dev", "https://yt.psmarcin.me":
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+	}
+}

--- a/pkg/utils/response_test.go
+++ b/pkg/utils/response_test.go
@@ -1,11 +1,12 @@
 package utils
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJSONResponse(t *testing.T) {
@@ -89,6 +90,65 @@ func TestWriteBodyResponse(t *testing.T) {
 			w := tt.args.w.Result()
 			body, _ := ioutil.ReadAll(w.Body)
 			assert.Equal(string(body), tt.args.body)
+		})
+	}
+}
+
+func TestAllowCorsResponse(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	type args struct {
+		w      *httptest.ResponseRecorder
+		r      *http.Request
+		origin string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Set proper CORS headers",
+			args: args{
+				w:      httptest.NewRecorder(),
+				r:      req,
+				origin: "http://localhost:8080",
+			},
+			want: "http://localhost:8080",
+		},
+		{
+			name: "Don't set CORS headers for not allowe domain",
+			args: args{
+				w:      httptest.NewRecorder(),
+				r:      req,
+				origin: "http://fake.domain",
+			},
+			want: "",
+		},
+		{
+			name: "Set CORS headers for allowed domain https://yt.psmarcin.dev",
+			args: args{
+				w:      httptest.NewRecorder(),
+				r:      req,
+				origin: "https://yt.psmarcin.dev",
+			},
+			want: "https://yt.psmarcin.dev",
+		},
+		{
+			name: "Set CORS headers for allowed domain https://yt.psmarcin.me",
+			args: args{
+				w:      httptest.NewRecorder(),
+				r:      req,
+				origin: "https://yt.psmarcin.me",
+			},
+			want: "https://yt.psmarcin.me",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req.Header.Set("origin", tt.args.origin)
+			AllowCorsResponse(tt.args.w, tt.args.r)
+			response := tt.args.w.Result()
+			assert.Equal(t, response.Header.Get("Access-Control-Allow-Origin"), tt.want)
 		})
 	}
 }


### PR DESCRIPTION
### Context
We need to allow CORS request from ui domains like: `https://yt.psmarcin.dev` to access our trending resources.

### Changes
* [x] Allow `/trending` route to be accessible from `https://yt.psmarcin.dev`
* [x] Unit tests

### How to test
1. Do request from browser from `http://localhost:8080`, `https://yt.psmarcin.dev` or `https://yt.psmarcin.me`

### Expectation
1. CI 🍏 
1. Proper response with list of trending channels
