### PR TITLE
feat(channels): create /channels endpoint

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/sirupsen/logrus"
 	"net/http"
+	"ytg/pkg/channels"
 	"ytg/pkg/config"
 	"ytg/pkg/trending"
 	"ytg/pkg/utils"
@@ -19,6 +20,7 @@ func Start() {
 func startMultiplex() {
 	http.HandleFunc("/", rootHandler)
 	http.HandleFunc("/trending", trending.Handler)
+	http.HandleFunc("/channels", channels.Handler)
 	logrus.Infof("[API] Port %s", config.Cfg.Port)
 	logrus.Fatal(http.ListenAndServe(":"+config.Cfg.Port, nil))
 }

--- a/pkg/channels/channels.go
+++ b/pkg/channels/channels.go
@@ -1,0 +1,10 @@
+package channels
+
+import (
+	"net/http"
+)
+
+// Handler is default router handler for GET /channel endpoint
+func Handler(w http.ResponseWriter, r *http.Request) {
+
+}

--- a/pkg/channels/channels.go
+++ b/pkg/channels/channels.go
@@ -2,9 +2,17 @@ package channels
 
 import (
 	"net/http"
+	"ytg/pkg/utils"
+	"ytg/pkg/youtube"
 )
 
 // Handler is default router handler for GET /channel endpoint
 func Handler(w http.ResponseWriter, r *http.Request) {
-
+	q := r.FormValue("q")
+	channels := youtube.GetChannels(q)
+	serialied := youtube.Serialize(channels)
+	utils.JSONResponse(w)
+	utils.AllowCorsResponse(w, r)
+	utils.OkResponse(w)
+	utils.WriteBodyResponse(w, serialied)
 }

--- a/pkg/trending/trending.go
+++ b/pkg/trending/trending.go
@@ -11,7 +11,7 @@ import (
 func Handler(w http.ResponseWriter, r *http.Request) {
 	logrus.Infof("[API] request %s %s", r.Method, r.RequestURI)
 	response := youtube.GetTrendings()
-	serialied := youtube.SerializeTrending(response)
+	serialied := youtube.Serialize(response)
 	utils.JSONResponse(w)
 	utils.AllowCorsResponse(w, r)
 	utils.OkResponse(w)

--- a/pkg/youtube/channels.go
+++ b/pkg/youtube/channels.go
@@ -6,15 +6,19 @@ import (
 )
 
 // GetChannels collects trendings from YouTube API
-func GetChannels() YoutubeResponse {
+func GetChannels(q string) YoutubeResponse {
 	trendings := YoutubeResponse{}
-	req, err := http.NewRequest("GET", YouTubeURL+"videos", nil)
+	req, err := http.NewRequest("GET", YouTubeURL+"search", nil)
 	if err != nil {
 		logrus.WithError(err).Fatal("[YT] Can't create new request")
 	}
 	query := req.URL.Query()
 	query.Add("part", "snippet")
-	query.Add("chart", "mostPopular")
+	query.Add("type", "channel")
+	query.Add("q", q)
+	query.Add("fields", "items(snippet(channelId,channelTitle,thumbnails/high,title))")
+	query.Add("order", "viewCount")
+	query.Add("maxResults", "5")
 	req.URL.RawQuery = query.Encode()
 
 	Request(req, &trendings)

--- a/pkg/youtube/channels.go
+++ b/pkg/youtube/channels.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 )
 
-// GetTrendings collects trendings from YouTube API
-func GetTrendings() YoutubeResponse {
+// GetChannels collects trendings from YouTube API
+func GetChannels() YoutubeResponse {
 	trendings := YoutubeResponse{}
 	req, err := http.NewRequest("GET", YouTubeURL+"videos", nil)
 	if err != nil {

--- a/pkg/youtube/trending_test.go
+++ b/pkg/youtube/trending_test.go
@@ -2,7 +2,7 @@ package youtube
 
 import "testing"
 
-func TestSerializeTrending(t *testing.T) {
+func TestSerialize(t *testing.T) {
 	type args struct {
 		channelResponse YoutubeResponse
 	}
@@ -47,8 +47,8 @@ func TestSerializeTrending(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SerializeTrending(tt.args.channelResponse); got != tt.want {
-				t.Errorf("SerializeTrending() = %v, want %v", got, tt.want)
+			if got := Serialize(tt.args.channelResponse); got != tt.want {
+				t.Errorf("Serialize() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/youtube/youtube.go
+++ b/pkg/youtube/youtube.go
@@ -1,0 +1,50 @@
+package youtube
+
+import (
+	"encoding/json"
+	"github.com/sirupsen/logrus"
+)
+
+type YoutubeResponse struct {
+	Items []Items `json:"items"`
+}
+type High struct {
+	URL    string `json:"url"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+}
+type Thumbnails struct {
+	High High `json:"high"`
+}
+type Snippet struct {
+	ChannelID    string     `json:"channelId"`
+	Title        string     `json:"title"`
+	Thumbnails   Thumbnails `json:"thumbnails"`
+	ChannelTitle string     `json:"channelTitle"`
+}
+type Items struct {
+	Snippet Snippet `json:"snippet"`
+}
+
+type Channel struct {
+	ChannelId string `json:"channelId"`
+	Thumbnail string `json:"thumbnail"`
+	Title     string `json:"title"`
+}
+
+// Serialize returns mapped channels with channelId, thumbnail and title
+func Serialize(channelResponse YoutubeResponse) string {
+	channels := []Channel{}
+	for _, item := range channelResponse.Items {
+		channels = append(channels, Channel{
+			ChannelId: item.Snippet.ChannelID,
+			Thumbnail: item.Snippet.Thumbnails.High.URL,
+			Title:     item.Snippet.ChannelTitle,
+		})
+	}
+	serialized, err := json.Marshal(channels)
+	if err != nil {
+		logrus.WithError(err).Info("[YT] Serialization")
+	}
+	return string(serialized)
+}


### PR DESCRIPTION
### Context
We need endpoint to get channels based on query string `q` for UI autocomplete.

### Changes
* [x] add `GET /channel` endpoint
* [x] refactor `trending` and `youtube` package to be reusable for `channels` 