### PR TITLE
feat: implement gorilla mux router

### DIFF
--- a/.realize.yaml
+++ b/.realize.yaml
@@ -1,38 +1,23 @@
 settings:
-  files:
-    outputs:
-      status: false
-      path: ""
-      name: .r.outputs.log
-    logs:
-      status: false
-      path: ""
-      name: .r.logs.log
-    errors:
-      status: false
-      path: ""
-      name: .r.errors.log
   legacy:
     force: false
-    interval: 0s
+    interval: 1s
 schema:
 - name: ygp-api
   path: /Users/psmarcin/projects/ygp-api
   commands:
     clean:
-      status: true
+      status: false
     vet:
-      status: true
+      status: false
     fmt:
-      status: true
+      status: false
     test:
-      status: true
+      status: false
     generate:
-      status: true
+      status: false
     install:
-      status: true
-    build:
-      status: true
+      status: false
     run:
       status: true
   watcher:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/caarlos0/env v3.5.0+incompatible
+	github.com/gorilla/mux v1.7.1
 	github.com/joho/godotenv v1.3.0
 	github.com/prometheus/client_golang v0.9.2
 	github.com/sirupsen/logrus v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/gorilla/mux v1.7.1 h1:Dw4jY2nghMMRsh1ol8dv1axHkDwMQK2DHerMNJsIpJU=
+github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"net/http"
 	"ytg/pkg/channels"
 	"ytg/pkg/config"
+	"ytg/pkg/logger"
 	"ytg/pkg/trending"
 	"ytg/pkg/utils"
 	"ytg/pkg/video"
@@ -20,17 +22,26 @@ func Start() {
 }
 
 func startMultiplex() {
-	http.HandleFunc("/", rootHandler)
-	http.HandleFunc("/trending", trending.Handler)
-	http.HandleFunc("/channels", channels.Handler)
-	http.HandleFunc("/video.mp3", video.Handler)
-	http.Handle("/metrics", promhttp.Handler())
+	// router init
+	router := mux.NewRouter()
+
+	// middleware
+	router.Use(logger.Middleware)
+	router.Use(utils.MiddlewareJSON)
+	router.Use(utils.MiddlewareCORS)
+	// routes
+	router.HandleFunc("/", rootHandler).Methods("GET")
+	router.HandleFunc("/trending", trending.Handler).Methods("GET")
+	router.HandleFunc("/channels", channels.Handler).Methods("GET")
+	router.HandleFunc("/video/{videoId}.mp3", video.Handler).Methods("GET")
+	router.HandleFunc("/video", video.RedirectHandler).Methods("GET")
+	router.Handle("/metrics", promhttp.Handler())
+	http.Handle("/", router)
 	logrus.Infof("[API] Port %s", config.Cfg.Port)
 	logrus.Fatal(http.ListenAndServe(":"+config.Cfg.Port, nil))
 }
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {
-	logrus.Infof("[API] request %s %s", r.Method, r.RequestURI)
 	utils.JSONResponse(w)
 	utils.OkResponse(w)
 	utils.WriteBodyResponse(w, RootJSON)

--- a/pkg/channels/channels.go
+++ b/pkg/channels/channels.go
@@ -1,7 +1,6 @@
 package channels
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"ytg/pkg/utils"
 	"ytg/pkg/youtube"
@@ -9,12 +8,9 @@ import (
 
 // Handler is default router handler for GET /channel endpoint
 func Handler(w http.ResponseWriter, r *http.Request) {
-	logrus.Infof("[API] request %s %s", r.Method, r.RequestURI)
 	q := r.FormValue("q")
 	channels := youtube.GetChannels(q)
 	serialied := youtube.Serialize(channels)
-	utils.JSONResponse(w)
-	utils.AllowCorsResponse(w, r)
 	utils.OkResponse(w)
 	utils.WriteBodyResponse(w, serialied)
 }

--- a/pkg/logger/middleware.go
+++ b/pkg/logger/middleware.go
@@ -1,0 +1,14 @@
+package logger
+
+import (
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+// Middleware act as middleware and log request method and path
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logrus.Infof("[API] Request %s %s", r.Method, r.RequestURI)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/trending/trending.go
+++ b/pkg/trending/trending.go
@@ -1,7 +1,6 @@
 package trending
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"ytg/pkg/utils"
 	"ytg/pkg/youtube"
@@ -9,11 +8,8 @@ import (
 
 // Handler is a entrypoint for router
 func Handler(w http.ResponseWriter, r *http.Request) {
-	logrus.Infof("[API] request %s %s", r.Method, r.RequestURI)
 	response := youtube.GetTrendings()
 	serialied := youtube.Serialize(response)
-	utils.JSONResponse(w)
-	utils.AllowCorsResponse(w, r)
 	utils.OkResponse(w)
 	utils.WriteBodyResponse(w, serialied)
 }

--- a/pkg/utils/middleware.go
+++ b/pkg/utils/middleware.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"net/http"
+)
+
+// MiddlewareJSON set header to response with JSON
+func MiddlewareJSON(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		JSONResponse(w)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// MiddlewareCORS set header to proper CORS headers
+func MiddlewareCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		AllowCorsResponse(w, r)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/utils/response.go
+++ b/pkg/utils/response.go
@@ -31,5 +31,11 @@ func AllowCorsResponse(w http.ResponseWriter, r *http.Request) {
 // Redirect set headers and statusCode to sent redirect response
 func Redirect(w http.ResponseWriter, location string) {
 	w.Header().Set("location", location)
-	w.WriteHeader(http.StatusTemporaryRedirect)
+	w.WriteHeader(http.StatusFound)
+}
+
+// PermanentRedirect set headers and statusCode to sent redirect response
+func PermanentRedirect(w http.ResponseWriter, location string) {
+	w.Header().Set("location", location)
+	w.WriteHeader(http.StatusPermanentRedirect)
 }

--- a/pkg/video/handler.go
+++ b/pkg/video/handler.go
@@ -1,19 +1,25 @@
 package video
 
 import (
-	"github.com/sirupsen/logrus"
+	"github.com/gorilla/mux"
 	"net/http"
 	"ytg/pkg/utils"
 )
 
 // Handler handles GET /video?videoId= route
 func Handler(w http.ResponseWriter, r *http.Request) {
-	logrus.Infof("[API] request %s %s", r.Method, r.RequestURI)
-	videoID := r.FormValue("videoId")
+	params := mux.Vars(r)
+	videoID := params["videoId"]
+
 	videoURL := GetURL(videoID)
 	if videoURL == "" {
 		http.NotFound(w, r)
 		return
 	}
 	utils.Redirect(w, videoURL)
+}
+
+// RedirectHandler is legacy handler for old routes, it redirect to new route
+func RedirectHandler(w http.ResponseWriter, r *http.Request) {
+	utils.PermanentRedirect(w, "/video/"+r.FormValue("videoId")+".mp3")
 }


### PR DESCRIPTION
### Context
We need to use path params for `GET /video/:videoId.mp3` route. The simples solution for that is to use github.com/gorilla/mux server. 

### Changes
* [x] use gorilla mux router
* [x] add logger and some helper middlewares
* [x] realize config update
* [x] support `GET /video/:videoId.mp3` route