### PR TITLE
test(video): improve test coverage

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -36,6 +36,7 @@ func startMultiplex() {
 	router.HandleFunc("/trending", trending.Handler).Methods("GET")
 	router.HandleFunc("/channels", channels.Handler).Methods("GET")
 	router.HandleFunc("/video/{videoId}.mp3", video.Handler).Methods("GET", "HEAD")
+	router.HandleFunc("/video/{videoId}.mp4", video.Handler).Methods("GET", "HEAD")
 	router.HandleFunc("/video", video.RedirectHandler).Methods("GET", "HEAD")
 	router.HandleFunc("/feed/channel/{channelId}", feed.Handler).Methods("GET", "HEAD")
 	router.Handle("/metrics", promhttp.Handler())

--- a/pkg/feed/items.go
+++ b/pkg/feed/items.go
@@ -85,7 +85,7 @@ func (f *Feed) setVideos(videos VideosResponse) error {
 	for i, video := range videos.Items {
 		s := video.Snippet
 		go func(video VideosItems, i int) error {
-			videoURL := os.Getenv("API_URL") + "video/" + video.ID.VideoID + ".mp3"
+			videoURL := os.Getenv("API_URL") + "video/" + video.ID.VideoID + ".mp4"
 			fileDetails, _ := getVideoFileDetails(videoURL)
 			videoDetails, err := getVideoDetails(video.ID.VideoID)
 			if err != nil {

--- a/pkg/video/handler_test.go
+++ b/pkg/video/handler_test.go
@@ -1,0 +1,40 @@
+package video
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestHandler(t *testing.T) {
+	type args struct {
+		w *httptest.ResponseRecorder
+		r *http.Request
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/video/videoId.mp3", nil)
+	req = mux.SetURLVars(req, map[string]string{"videoId": "NtQkz0aRDe8"})
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "videoID: uwfdFCP3KYM",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: req,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Handler(tt.args.w, tt.args.r)
+			if tt.args.w.Code != http.StatusFound {
+				t.Errorf("Handler(): %+v want %+v ", tt.args.w.Code, http.StatusFound)
+			}
+		})
+	}
+}

--- a/pkg/video/video.go
+++ b/pkg/video/video.go
@@ -5,11 +5,14 @@ import (
 )
 
 var audioFormats = []Format{
+	FORMATS[141],
 	FORMATS[140],
+	FORMATS[139],
 	FORMATS[171],
+	FORMATS[251],
 	FORMATS[250],
 	FORMATS[249],
-	FORMATS[251],
+	FORMATS[18],
 }
 
 // GetURL returns video URL based on videoID

--- a/pkg/video/video_test.go
+++ b/pkg/video/video_test.go
@@ -1,0 +1,83 @@
+package video
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestGetURL(t *testing.T) {
+	type args struct {
+		videoID string
+	}
+	type want struct {
+		url string
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "videoID: tGL4tKXkA4U",
+			args: args{
+				videoID: "tGL4tKXkA4U",
+			},
+			want: want{
+				url: "googlevideo.com/videoplayback",
+			},
+		},
+		{
+			name: "videoID: oIbEvwzLxgE",
+			args: args{
+				videoID: "oIbEvwzLxgE",
+			},
+			want: want{
+				url: "googlevideo.com/videoplayback",
+			},
+		},
+		{
+			name: "videoID: oIbEvwzLxgE1",
+			args: args{
+				videoID: "oIbEvwzLxgE1",
+			},
+			want: want{
+				url: "googlevideo.com/videoplayback",
+			},
+		},
+		{
+			name: "videoID: uwfdFCP3KYM",
+			args: args{
+				videoID: "uwfdFCP3KYM",
+			},
+			want: want{
+				url: "googlevideo.com/videoplayback",
+			},
+		},
+		{
+			name: "videoID: _kMShzhW3KE",
+			args: args{
+				videoID: "_kMShzhW3KE",
+			},
+			want: want{
+				url: "googlevideo.com/videoplayback",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetURL(tt.args.videoID)
+			containsURL := strings.Contains(got, tt.want.url)
+			foundFormat := false
+			for _, audioFormat := range audioFormats {
+				if strings.Contains(got, strconv.Itoa(audioFormat.Itag)) {
+					foundFormat = true
+					break
+				}
+			}
+			if !containsURL || !foundFormat {
+				t.Errorf("GetURL() = %v, want url: %v, formatFound %t", got, tt.want.url, foundFormat)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Context
Missing tests for video handler.

### Changes
1. Video tests
1. Create `GET HEAD /video/:videoId.mp4` route