### PR TITLE
fix(item): duration calculation

### DIFF
--- a/pkg/feed/items.go
+++ b/pkg/feed/items.go
@@ -2,6 +2,7 @@ package feed
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -93,6 +94,7 @@ func (f *Feed) setVideos(videos VideosResponse) error {
 				stream <- Item{}
 				return err
 			}
+
 			stream <- Item{
 				GUID:        video.ID.VideoID,
 				Title:       s.Title,
@@ -113,7 +115,7 @@ func (f *Feed) setVideos(videos VideosResponse) error {
 					Href: getImageURL(s.Thumbnails.High.URL),
 				},
 				ITExplicit: "no",
-				ITDuration: videoDetails.Duration.String(),
+				ITDuration: calculateDuration(videoDetails.Duration),
 				ITOrder:    strconv.Itoa(i),
 			}
 			return nil
@@ -188,4 +190,14 @@ func normalizeDurationString(duration string) string {
 
 func getImageURL(src string) string {
 	return src
+}
+
+func calculateDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	h := d / time.Hour
+	d -= h * time.Hour
+	m := d / time.Minute
+	d -= m * time.Minute
+	s := d / time.Second
+	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
 }

--- a/pkg/feed/items_test.go
+++ b/pkg/feed/items_test.go
@@ -281,3 +281,40 @@ func TestFeed_getVideos(t *testing.T) {
 		})
 	}
 }
+
+func Test_calculateDuration(t *testing.T) {
+	type args struct {
+		d time.Duration
+	}
+
+	duration1h00m10s, _ := time.ParseDuration("1h00m10s")
+	duration123h59m59s, _ := time.ParseDuration("123h59m59s")
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "1h00m10s",
+			args: args{
+				d: duration1h00m10s,
+			},
+			want: "01:00:10",
+		},
+		{
+			name: "123h59m59s",
+			args: args{
+				d: duration123h59m59s,
+			},
+			want: "123:59:59",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateDuration(tt.args.d); got != tt.want {
+				t.Errorf("calculateDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Context
I used to use duration format like `01h12m59s` but it looks like Apple podcasts doesn't like it. They use `01:12:59`. 

### Changes
1. Add `calculateDuration` function
1. Test cases for new function