### PR TITLE
feat: query string search allows to filter by title

### DIFF
--- a/pkg/feed/handler.go
+++ b/pkg/feed/handler.go
@@ -15,7 +15,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		handleError(w, err)
 		return
 	}
-	videos, err := f.getVideos()
+	searchPhrase := r.FormValue("search")
+	videos, err := f.getVideos(searchPhrase)
 	if err != nil {
 		handleError(w, err)
 		return

--- a/pkg/feed/items.go
+++ b/pkg/feed/items.go
@@ -58,7 +58,7 @@ type VideosDetailsContent struct {
 	Duration string `json:"duration"`
 }
 
-func (f *Feed) getVideos() (VideosResponse, error) {
+func (f *Feed) getVideos(q string) (VideosResponse, error) {
 	videos := VideosResponse{}
 	req, err := http.NewRequest("GET", youtube.YouTubeURL+"search", nil)
 	if err != nil {
@@ -70,6 +70,7 @@ func (f *Feed) getVideos() (VideosResponse, error) {
 	query.Add("order", "date")
 	query.Add("channelId", f.ChannelID)
 	query.Add("maxResults", "10")
+	query.Add("q", q)
 	query.Add("fields", "items(id,snippet(channelId,channelTitle,description,publishedAt,thumbnails/high,title))")
 	req.URL.RawQuery = query.Encode()
 

--- a/pkg/feed/items_test.go
+++ b/pkg/feed/items_test.go
@@ -270,7 +270,7 @@ func TestFeed_getVideos(t *testing.T) {
 				Get("/youtube/v3/search").
 				Reply(status).
 				BodyString(response)
-			got, err := f.getVideos()
+			got, err := f.getVideos("123")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Feed.getVideos() error = %+v, wantErr %+v", err, tt.wantErr)
 				return


### PR DESCRIPTION
### Context
Missing feature that UI has and new API wasn't able to do. Query param for `GET /feed/channel/:channelId?search=SEARCH_PHRASE`.

### Changes
* [x] Get param from query string, default is empty string
* [x] Pass that value to request to youtube api
* [x] Update tests

### How to test
1. `make dev` 
1. Request `GET http :8080/feed/channel/UC_7PqixGIdE-jjoHKMPYpGA?search=kiedy`

### Expected
1. Should return only items with title contains `kiedy` world