### PR TITLE
feat: fallback for random video if no audio found

### DIFF
--- a/pkg/video/handler.go
+++ b/pkg/video/handler.go
@@ -2,6 +2,9 @@ package video
 
 import (
 	"net/http"
+
+	"github.com/sirupsen/logrus"
+
 	"ygp/pkg/utils"
 
 	"github.com/gorilla/mux"
@@ -14,6 +17,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	videoURL := GetURL(videoID)
 	if videoURL == "" {
+		logrus.Infof("didn't find video (%s) with audio", videoID)
 		http.NotFound(w, r)
 		return
 	}


### PR DESCRIPTION
### Context
Sometimes video details that we get don't have any "audio" stream. Instead of throwing error `404 Not Found` we should return any valid stream (including video). 

### Changes
* [x] Add fallback for video streams 