### PR TITLE
feat: enable video file details cache

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -89,7 +89,6 @@ func CreateHTTPServer() *fiber.App {
 
 func CreateDependencies(deps Dependencies) (feed.Dependencies, video.Dependencies) {
 	vd := video.Dependencies{
-		Details:    video.HeadRequest,
 		Info:       ytdl.GetVideoInfo,
 		GetFileUrl: video.GetVideoUrl,
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -12,7 +12,7 @@ import (
 	"github.com/psmarcin/youtubegoespodcast/pkg/config"
 )
 
-// Cache keeps firestor client and colletion
+// Cache keeps firestore client and collection
 type Cache struct {
 	firestore  *firestore.Client
 	collection *firestore.CollectionRef

--- a/pkg/feed/feed_test.go
+++ b/pkg/feed/feed_test.go
@@ -111,8 +111,6 @@ func TestCreateShouldReturnFeedWithVideo1(t *testing.T) {
 
 	assert.Equal(t, f.ChannelID, "123")
 	assert.Len(t, f.Content.Items, 1)
-	assert.Equal(t, f.Items[0].Details.ContentLength, int64(123))
-	assert.Equal(t, f.Items[0].Details.ContentType, "mp3")
 	assert.Equal(t, f.Items[0].Details.Title, "Title Video")
 	assert.Equal(t, f.Items[0].Details.Description, "Description Video")
 	assert.Equal(t, f.Items[0].Details.FileUrl.String(), "http://onet.pl")

--- a/pkg/video/details.go
+++ b/pkg/video/details.go
@@ -1,0 +1,67 @@
+package video
+
+import (
+	"errors"
+	"github.com/psmarcin/youtubegoespodcast/pkg/cache"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	cacheKeyPrefix = "video_file_details_"
+	cacheTTL       = time.Hour * 24 * 31
+)
+
+type FileDetails struct {
+	ContentType   string `json:"contentType"`
+	ContentLength int64  `json:"contentLength"`
+}
+
+func (f FileDetails) Get(url *url.URL) (FileDetails, error) {
+	resp, err := http.Head(url.String())
+	if err != nil {
+		return f, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return f, errors.New("[ITEM] Can't get file details for " + url.String())
+	}
+	ct := resp.Header.Get("Content-Type")
+	cl := resp.Header.Get("Content-Length")
+	if ct == "" || cl == "" {
+		return f, errors.New("can't get details content-type: " + ct + ", content-length: " + cl)
+	}
+	f.ContentType = ct
+
+	clParsed, err := strconv.ParseInt(cl, 10, 32)
+	if err != nil {
+		l.WithError(err).Errorf("can't parse content-length: " + cl)
+		return f, err
+	}
+
+	f.ContentLength = clParsed
+	return f, nil
+}
+
+func (f FileDetails) GetCache(url *url.URL, id string) (FileDetails, error) {
+	cacheKey := cacheKeyPrefix + id
+	_, err := cache.Client.GetKey(cacheKey, &f)
+	if err == nil {
+		return f, nil
+	}
+
+	f, err = f.Get(url)
+	if err != nil {
+		return f, err
+	}
+
+	go cache.Client.MarshalAndSetKey(cacheKey, f, cacheTTL)
+
+	return f, nil
+}
+
+type FileDetailsDeps interface {
+	Get(url.URL) (FileDetails, error)
+	GetCache(url.URL, string) (FileDetails, error)
+}


### PR DESCRIPTION
### Context
Enable video file details cache. This should prevent http status code 429 from source server. 

### Changes
1. Cache each video file details for 31 days. 