### PR TITLE
feat: add channel thumbnail support

### DIFF
--- a/internal/adapters/youtube-videos.go
+++ b/internal/adapters/youtube-videos.go
@@ -137,7 +137,7 @@ func mapFeedToYouTubeEntry(entry FeedEntry) (app.YouTubeFeedEntry, error) {
 		Description: entry.Group.Description,
 		Published:   publishedAt,
 		URL:         *u,
-		Thumbnail: app.YouTubeFeedThumbnail{
+		Thumbnail: app.YouTubeThumbnail{
 			Height: tHeight,
 			Width:  tWidth,
 			Url:    *tUrl,

--- a/internal/adapters/youtube_test.go
+++ b/internal/adapters/youtube_test.go
@@ -1,0 +1,186 @@
+package adapters
+
+import (
+	"github.com/psmarcin/youtubegoespodcast/internal/app"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/youtube/v3"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func Test_mapChannelItemToYouTubeChannels(t *testing.T) {
+	pubString := "2006-01-02T15:04:05Z"
+	pubTime, _ := time.Parse(time.RFC3339, pubString)
+	urlString := "https://yt.google.com"
+	urlParsed, _ := url.Parse(urlString)
+
+	type args struct {
+		item *youtube.Channel
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    app.YouTubeChannel
+		wantErr bool
+	}{
+		{
+			name: "should map thumbnail",
+			args: args{
+				item: &youtube.Channel{
+					Snippet: &youtube.ChannelSnippet{
+						Thumbnails: &youtube.ThumbnailDetails{
+							High: &youtube.Thumbnail{
+								Height: 500,
+								Url:    urlString,
+								Width:  300,
+							},
+						},
+						PublishedAt: "2006-01-02T15:04:05Z",
+					},
+				},
+			},
+			want: app.YouTubeChannel{
+				AuthorEmail: "email@example.com",
+				PublishedAt: pubTime,
+				Thumbnail: app.YouTubeThumbnail{
+					Height: 500,
+					Width:  300,
+					Url:    *urlParsed,
+				},
+				Url: YouTubeChannelBaseURL,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should map thumbnail even without valid url",
+			args: args{
+				item: &youtube.Channel{
+					Snippet: &youtube.ChannelSnippet{
+						Thumbnails: &youtube.ThumbnailDetails{
+							High: &youtube.Thumbnail{
+								Height: 500,
+								Url:    "x",
+								Width:  300,
+							},
+						},
+						PublishedAt: "2006-01-02T15:04:05Z",
+					},
+				},
+			},
+			want: app.YouTubeChannel{
+				AuthorEmail: "email@example.com",
+				PublishedAt: pubTime,
+				Thumbnail: app.YouTubeThumbnail{
+					Height: 500,
+					Width:  300,
+					Url: url.URL{
+						Path: "x",
+					},
+				},
+				Url: YouTubeChannelBaseURL,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapChannelToYouTubeChannel(tt.args.item)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mapChannelToYouTubeChannel() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func Test_mapSearchItemToYouTubeChannel(t *testing.T) {
+	pubString := "2006-01-02T15:04:05Z"
+	pubTime, _ := time.Parse(time.RFC3339, pubString)
+	urlString := "https://yt.google.com"
+	urlParsed, _ := url.Parse(urlString)
+
+	type args struct {
+		item *youtube.SearchResult
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    app.YouTubeChannel
+		wantErr bool
+	}{
+		{
+			name: "should map thumbnail",
+			args: args{
+				item: &youtube.SearchResult{
+					Id: &youtube.ResourceId{
+						ChannelId: "1",
+					},
+					Snippet: &youtube.SearchResultSnippet{
+						PublishedAt: pubString,
+						Thumbnails: &youtube.ThumbnailDetails{
+							Default: &youtube.Thumbnail{
+								Height: 500,
+								Url:    urlString,
+								Width:  1,
+							},
+						},
+					},
+				},
+			},
+			want: app.YouTubeChannel{
+				ChannelId:   "1",
+				PublishedAt: pubTime,
+				Thumbnail: app.YouTubeThumbnail{
+					Height: 500,
+					Width:  1,
+					Url:    *urlParsed,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "should map thumbnail url without valid url",
+			args: args{
+				item: &youtube.SearchResult{
+					Id: &youtube.ResourceId{
+						ChannelId: "1",
+					},
+					Snippet: &youtube.SearchResultSnippet{
+						PublishedAt: pubString,
+						Thumbnails: &youtube.ThumbnailDetails{
+							Default: &youtube.Thumbnail{
+								Height: 500,
+								Url:    "x",
+								Width:  1,
+							},
+						},
+					},
+				},
+			},
+			want: app.YouTubeChannel{
+				ChannelId:   "1",
+				PublishedAt: pubTime,
+				Thumbnail: app.YouTubeThumbnail{
+					Height: 500,
+					Width:  1,
+					Url: url.URL{
+						Path: "x",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapSearchItemToYouTubeChannel(tt.args.item)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mapSearchItemToYouTubeChannel() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}

--- a/internal/app/feed.go
+++ b/internal/app/feed.go
@@ -3,7 +3,7 @@ package app
 import (
 	"fmt"
 	"github.com/eduncan911/podcast"
-	feed2 "github.com/psmarcin/youtubegoespodcast/internal/domain/feed"
+	feedDomain "github.com/psmarcin/youtubegoespodcast/internal/domain/feed"
 	"github.com/rylio/ytdl"
 	"net/url"
 	"os"
@@ -59,7 +59,7 @@ func NewFeedService(
 }
 
 func (f FeedService) Create(channelID string) (Feed, error) {
-	podcastFeed, err := f.GetDetails(channelID)
+	podcastFeed, err := f.GetFeedInformation(channelID)
 	feed := Feed{
 		ChannelID: channelID,
 		Content:   podcastFeed,
@@ -92,13 +92,13 @@ func (f FeedService) Create(channelID string) (Feed, error) {
 		return feed, err
 	}
 
-	feed.Content.Items = feed2.SortByPubDate(feed.Content.Items)
+	feed.Content.Items = feedDomain.SortByPubDate(feed.Content.Items)
 	feed.Content.Generator = Generator
 
 	return feed, nil
 }
 
-func (f *FeedService) GetDetails(channelID string) (podcast.Podcast, error) {
+func (f *FeedService) GetFeedInformation(channelID string) (podcast.Podcast, error) {
 	var fee podcast.Podcast
 	channel, err := f.youtubeService.GetChannelCache(channelID)
 	if err != nil {
@@ -112,13 +112,12 @@ func (f *FeedService) GetDetails(channelID string) (podcast.Podcast, error) {
 	fee.AddCategory("Arts", []string{"Design"})
 	fee.Language = channel.Country
 	fee.Image = &podcast.Image{
-		URL:         channel.Thumbnail,
+		URL:         channel.Thumbnail.Url.String(),
 		Title:       channel.Title,
 		Link:        channel.Url,
 		Description: channel.Description,
-		//TODO: add width and height for thumbnail
-		Width:  0,
-		Height: 0,
+		Width:       channel.Thumbnail.Width,
+		Height:      channel.Thumbnail.Height,
 	}
 	fee.AddAuthor(channel.Author, channel.AuthorEmail)
 

--- a/internal/app/feed_test.go
+++ b/internal/app/feed_test.go
@@ -276,7 +276,7 @@ func TestFeed_GetDetails(t *testing.T) {
 					Country:     "pl1",
 					Description: "d1",
 					PublishedAt: time.Date(2000, 11, 01, 1, 1, 1, 1, time.UTC),
-					Thumbnail:   "th1",
+					Thumbnail:   YouTubeThumbnail{},
 					Title:       "t1",
 					Url:         "u1",
 				}, nil)
@@ -305,15 +305,15 @@ func TestFeed_GetDetails(t *testing.T) {
 
 			tt.before()
 
-			pod, err := feedService.GetDetails(tt.args.channelID)
+			pod, err := feedService.GetFeedInformation(tt.args.channelID)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetDetails() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetFeedInformation() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if pod.Title != tt.expect.Title &&
 				pod.Description != tt.expect.Description &&
 				pod.Link != tt.expect.Link {
-				t.Errorf("GetDetails() get = %v, want = %v", f.Content, tt.expect)
+				t.Errorf("GetFeedInformation() get = %v, want = %v", f.Content, tt.expect)
 			}
 		})
 	}

--- a/internal/app/youtube.go
+++ b/internal/app/youtube.go
@@ -28,10 +28,10 @@ type YouTubeFeedEntry struct {
 	Description string
 	Published   time.Time
 	URL         url.URL
-	Thumbnail   YouTubeFeedThumbnail
+	Thumbnail   YouTubeThumbnail
 }
 
-type YouTubeFeedThumbnail struct {
+type YouTubeThumbnail struct {
 	Height int
 	Width  int
 	Url    url.URL
@@ -45,7 +45,7 @@ type YouTubeChannel struct {
 	Country     string
 	Description string
 	PublishedAt time.Time
-	Thumbnail   string
+	Thumbnail   YouTubeThumbnail
 	Title       string
 	Url         string
 }
@@ -84,7 +84,7 @@ func (y YouTubeService) GetChannelCache(channelId string) (YouTubeChannel, error
 		return channel, nil
 	}
 
-	response, err := y.youTubeApiRepository.GetChannel(channelId)
+	response, err := y.GetChannel(channelId)
 	if err != nil {
 		return channel, errors.Wrapf(err, "unable value get channel for channel id: %s", channelId)
 	}
@@ -103,7 +103,7 @@ func (y YouTubeService) ListChannelCache(query string) ([]YouTubeChannel, error)
 		return channels, nil
 	}
 
-	response, err := y.youTubeApiRepository.ListChannel(query)
+	response, err := y.ListChannel(query)
 	if err != nil {
 		return channels, errors.Wrapf(err, "unable value list channel for query: %s", query)
 	}


### PR DESCRIPTION
### Context
Channel thumbnail size was missing and set to default `0` value for both width and height. 

### Changes
* [x] feed response with width and height of channel thumbnail 
* [x] tests 
* [x] minor refactor (mostly names) 