### PR TITLE
feat: integrate golangci-lint and fix all errors and warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         run: GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 
       - name: Lint
-        run: make lint
+        run: make lint-ci
 
       - name: Build
         run: make build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,15 @@ jobs:
 
       - name: Test
         run: make test
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ IMAGE_TAG=gcr.io/$(PROJECT_ID)/$(NAME)
 dev:
 	modd
 
-lint:
+lint-ci:
 	gofmt -w -s .
 	goimports -w .
+
+lint: lint-ci
 	golangci-lint run --fix
 
 dependencies:

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,12 @@ dev:
 lint:
 	gofmt -w -s .
 	goimports -w .
+	golangci-lint run --fix
 
 dependencies:
 	go mod download
 
-test: dependencies
+test:
 	go test ./...
 
 build: dependencies build-raw

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Use this url `https://yt.psmarcin.dev/feed/channel/UCblfuW_4rakIf2h6aqANefA` in 
 1. Modd (auto restart), more https://github.com/cortesi/modd
 1. Google Cloud Console or mocks 
 1. goimports: https://pkg.go.dev/golang.org/x/tools/cmd/goimports
+1. golangci-lint: https://golangci-lint.run/usage/install/
 
 ### Environment variables
 Example environment variables

--- a/internal/adapters/cache.go
+++ b/internal/adapters/cache.go
@@ -2,8 +2,9 @@ package adapters
 
 import (
 	"context"
-	"github.com/cockroachdb/errors"
 	"time"
+
+	"github.com/cockroachdb/errors"
 
 	"cloud.google.com/go/firestore"
 	"github.com/psmarcin/youtubegoespodcast/internal/config"
@@ -89,7 +90,7 @@ func (c *Cache) GetKey(ctx context.Context, key string) (string, error) {
 		return "", errors.Wrap(err, "can't parse raw data")
 	}
 
-	timeDiff := time.Now().Sub(raw.UpdateTime)
+	timeDiff := time.Since(raw.UpdateTime)
 	if timeDiff > e.Ttl {
 		l.Debugf("key expires, updated at %s, expires in %s", raw.UpdateTime.Format(time.RFC3339), e.Ttl.String())
 		span.RecordError(err)

--- a/internal/adapters/youtube-videos.go
+++ b/internal/adapters/youtube-videos.go
@@ -69,7 +69,7 @@ func init() {
 func (y YouTubeRepository) ListEntry(ctx context.Context, channelId string) ([]app.YouTubeFeedEntry, error) {
 	var entries []app.YouTubeFeedEntry
 	var f Feed
-	ctx, span := tracer.Start(ctx, "list-entry")
+	_, span := tracer.Start(ctx, "list-entry")
 	span.SetAttributes(label.String("channel-id", channelId))
 	defer span.End()
 

--- a/internal/adapters/youtube.go
+++ b/internal/adapters/youtube.go
@@ -37,7 +37,7 @@ func NewYouTubeAPIRepository(yt *youtube.Service) YouTubeAPIRepository {
 
 func (yt YouTubeAPIRepository) GetChannel(ctx context.Context, id string) (app.YouTubeChannel, error) {
 	var channel app.YouTubeChannel
-	ctx, span := tracer.Start(ctx, "get-channel")
+	_, span := tracer.Start(ctx, "get-channel")
 	span.SetAttributes(label.String("id", id))
 	defer span.End()
 
@@ -50,7 +50,7 @@ func (yt YouTubeAPIRepository) GetChannel(ctx context.Context, id string) (app.Y
 	if err != nil {
 		l.WithError(err).Errorf("youtube api request failed")
 		span.RecordError(err)
-		return channel, errors.Wrap(err,"can't make youtube api request to get channel")
+		return channel, errors.Wrap(err, "can't make youtube api request to get channel")
 	}
 
 	for _, item := range response.Items {
@@ -65,7 +65,7 @@ func (yt YouTubeAPIRepository) GetChannel(ctx context.Context, id string) (app.Y
 
 func (yt YouTubeAPIRepository) ListChannel(ctx context.Context, query string) ([]app.YouTubeChannel, error) {
 	var channels []app.YouTubeChannel
-	ctx, span := tracer.Start(ctx, "list-channel")
+	_, span := tracer.Start(ctx, "list-channel")
 	span.SetAttributes(label.String("query", query))
 	defer span.End()
 

--- a/internal/app/cache.go
+++ b/internal/app/cache.go
@@ -83,7 +83,7 @@ func (c *CacheService) Get(ctx context.Context, key string, to interface{}) erro
 }
 
 // MarshalAndSetKey is the same as SetKey but before that it marshals value. Simple helper
-func (c *CacheService) MarshalAndSet(ctx context.Context, key string, value interface{}) error {
+func (c *CacheService) MarshalAndSet(ctx context.Context, key string, value interface{}) {
 	tCtx, span := tracer.Start(ctx, "marshal-and-set")
 	span.SetAttributes(label.String("key", key))
 	span.SetAttributes(label.Any("value", value))
@@ -93,12 +93,11 @@ func (c *CacheService) MarshalAndSet(ctx context.Context, key string, value inte
 	if err != nil {
 		l.WithError(err).WithField("value", value).WithField("key", key).Errorf("can't marshal")
 		span.RecordError(err)
-		return errors.Wrapf(err, "can't serialize value: %+v for key: %s", value, key)
+		return
 	}
 	err = c.Set(tCtx, key, string(marshaled))
 	if err != nil {
 		l.WithError(err).Error("can't set marshaled value")
 		span.RecordError(err)
 	}
-	return nil
 }

--- a/internal/app/cache_test.go
+++ b/internal/app/cache_test.go
@@ -316,9 +316,7 @@ func TestCacheService_MarshalAndSet(t *testing.T) {
 				cache: tt.fields.cache,
 			}
 			tt.before()
-			if err := c.MarshalAndSet(context.Background(), tt.args.key, tt.args.value); (err != nil) != tt.wantErr {
-				t.Errorf("MarshalAndSet() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			c.MarshalAndSet(context.Background(), tt.args.key, tt.args.value)
 		})
 	}
 }

--- a/internal/app/feed_test.go
+++ b/internal/app/feed_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eduncan911/podcast"
 	"github.com/cockroachdb/errors"
+	"github.com/eduncan911/podcast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/app/file.go
+++ b/internal/app/file.go
@@ -2,12 +2,13 @@ package app
 
 import (
 	"context"
-	"github.com/cockroachdb/errors"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/cockroachdb/errors"
 
 	"github.com/kkdai/youtube"
 	"github.com/kkdai/youtube/pkg/decipher"
@@ -31,7 +32,7 @@ func NewFileService() FileService {
 
 func (f FileService) GetDetails(ctx context.Context, videoId string) (Details, error) {
 	details := Details{}
-	ctx, span := tracer.Start(ctx, "file-get-details")
+	_, span := tracer.Start(ctx, "file-get-details")
 	span.SetAttributes(label.String("videoId", videoId))
 	defer span.End()
 

--- a/internal/ports/error.go
+++ b/internal/ports/error.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	error404Message = "I'm so sorry, didn't find page that you are looking for. Please try again in a bit."
-	error500Message = "I'm so sorry, we have technical problem, please try again in a bit."
 )
 
 // errorHandler is server route handler for internal errors and not found routes


### PR DESCRIPTION
### Context
To keep codebase nice and organized I think it would be nice to have `golangci-lint` to keep an eye on each PR. 

### Changes
* [x] Integrate `golangci-lint` to `make lint` 
* [x] Update `README.md` file
* [x] Fix all problems from new linter
* [x] Integrate Github Action with linter